### PR TITLE
fix(cli): Read from File Path

### DIFF
--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -42,7 +42,7 @@ module.exports = ->
       process.exit(1)
       return
 
-    html = new delexe().renderSync({filePath: outputPath, scopeName: cli.argv.scope})
+    html = new delexe().renderSync({filePath, scopeName: cli.argv.scope})
     if outputPath
       fs.writeFileSync(outputPath, html)
     else


### PR DESCRIPTION
Basically a typo.

I was playing with it and noticed that while reading from `stdin` works like a charm, there was a problem when reading from a file.